### PR TITLE
チャット機能から来たコメントのtypeを「チャット」にする

### DIFF
--- a/packages/backend/src/models/comment.ts
+++ b/packages/backend/src/models/comment.ts
@@ -61,7 +61,7 @@ const commentSchema = new mongoose.Schema<IComment>({
   },
   sourceType: {
     type: String,
-    enum: ['youtube', 'x', 'form', 'other'],
+    enum: ['youtube', 'x', 'form', 'chat', 'other'],
     required: false,
   },
   sourceUrl: {

--- a/packages/chat-bot/src/index.ts
+++ b/packages/chat-bot/src/index.ts
@@ -186,7 +186,7 @@ ${userMessage}
     // 整理された内容をバックエンドに送信
     const commentResponse = await backendApi.post<CommentResponse>(`/projects/${projectId}/comments`, {
       content: analysisResult.content,
-      sourceType: 'other',
+      sourceType: 'chat',
       sourceUrl: null
     });
 

--- a/packages/frontend/src/components/CommentList.tsx
+++ b/packages/frontend/src/components/CommentList.tsx
@@ -70,6 +70,8 @@ export const CommentList = ({ comments, project }: CommentListProps) => {
         return 'bg-gray-900 text-white';
       case 'form':
         return 'bg-blue-100 text-blue-800';
+      case 'chat':
+        return 'bg-green-100 text-green-800';
       default:
         return 'bg-gray-100 text-gray-800';
     }
@@ -84,6 +86,8 @@ export const CommentList = ({ comments, project }: CommentListProps) => {
         return 'X (Twitter)';
       case 'form':
         return 'フォーム';
+      case 'chat':
+        return 'チャット';
       default:
         return 'その他';
     }

--- a/packages/frontend/src/components/StanceReport.tsx
+++ b/packages/frontend/src/components/StanceReport.tsx
@@ -106,6 +106,8 @@ export const StanceReport = ({ comments, project, initialQuestionId }: StanceAna
         return 'bg-gray-900 text-white';
       case 'form':
         return 'bg-blue-100 text-blue-800';
+      case 'chat':
+        return 'bg-green-100 text-green-800';
       default:
         return 'bg-gray-100 text-gray-800';
     }
@@ -120,6 +122,8 @@ export const StanceReport = ({ comments, project, initialQuestionId }: StanceAna
         return 'X (Twitter)';
       case 'form':
         return 'フォーム';
+      case 'chat':
+        return 'チャット';
       default:
         return 'その他';
     }

--- a/packages/frontend/src/pages/CsvUploadPage.tsx
+++ b/packages/frontend/src/pages/CsvUploadPage.tsx
@@ -326,7 +326,7 @@ const CsvUploadPage: React.FC = () => {
               />
             </label>
             <p className="mt-1 text-sm text-gray-500">
-              必要な列: content, sourceType ('youtube' | 'x' | 'form' | 'other' | null), sourceUrl (optional)
+              必要な列: content, sourceType ('youtube' | 'x' | 'form' | 'chat' | 'other' | null), sourceUrl (optional)
             </p>
           </div>
 {selectedFile && previewData?.isValid && !isProcessing && (

--- a/packages/frontend/src/types/comment.ts
+++ b/packages/frontend/src/types/comment.ts
@@ -1,4 +1,4 @@
-export type CommentSourceType = 'youtube' | 'x' | 'form' | 'other';
+export type CommentSourceType = 'youtube' | 'x' | 'form' | 'chat' | 'other';
 
 export interface CommentStance {
   questionId: string;


### PR DESCRIPTION
close #14 
# 変更の概要

- frontend
  - コメントのタイプに「チャット」を追加しました。
- backend
  -  コメントのタイプに「チャット」を追加しました。
- chat-bot
  - backendへの送信時ソースタイプをチャットに変更しました。

CSVアップロード画面での表示

![Screenshot from 2025-03-20 20-14-32](https://github.com/user-attachments/assets/3b0dfd38-9f30-4a88-bf37-fb31ef0695e0)

論点ごとの分析での表示

![Screenshot from 2025-03-20 20-16-34](https://github.com/user-attachments/assets/6b44ff2a-af36-44b3-a9be-9d4c25329ff4)

コメント一覧での表示

![Screenshot from 2025-03-20 20-14-03](https://github.com/user-attachments/assets/171793db-dd02-423f-8c65-12aad7bba31d)


# 変更の背景
- #14 

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](/takahiroanno2024/policy-repository/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
