### PR TITLE
微修正: .env.example の設定の補足説明を正しくなるように変更 を更新

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,5 +4,5 @@ MONGO_APP_USERNAME=app_user
 MONGO_APP_PASSWORD=app_password
 MONGO_EXPRESS_USERNAME=admin
 MONGO_EXPRESS_PASSWORD=admin123
-OPENROUTER_API_KEY=your_gemini_api_key_here
+OPENROUTER_API_KEY=your_openrouter_api_key_here
 ADMIN_API_KEY=your_admin_api_key_here # これは自由に決めてください。


### PR DESCRIPTION
# 変更の概要
- .env.example の設定の補足説明を正しくなるように変更

# 変更の背景
- 必要なキーがgeminiキーからOPENROUTERキーに変更されているのにも関わらず、説明にgeminiキーと書かれているため

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](/takahiroanno2024/policy-repository/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
