### PR TITLE
improve copy-env.sh

### DIFF
--- a/copy-env.sh
+++ b/copy-env.sh
@@ -3,10 +3,22 @@
 set -eux
 
 # ルートディレクトリ
-cp .env.example .env
+if [ -f .env ]; then
+  echo "警告: .env ファイルが既に存在します。上書きしません。"
+else
+  cp .env.example .env
+fi
 
 # バックエンド
-cp packages/backend/.env.example packages/backend/.env
+if [ -f packages/backend/.env ]; then
+  echo "警告: packages/backend/.env ファイルが既に存在します。上書きしません。"
+else
+  cp packages/backend/.env.example packages/backend/.env
+fi
 
 # フロントエンド
-cp packages/frontend/.env.example packages/frontend/.env
+if [ -f packages/frontend/.env ]; then
+  echo "警告: packages/frontend/.env ファイルが既に存在します。上書きしません。"
+else
+  cp packages/frontend/.env.example packages/frontend/.env
+fi


### PR DESCRIPTION
# 変更の概要
- https://github.com/digitaldemocracy2030/idobata-analyst/pull/48 で導入された copy-env.sh を改善した

# 変更の背景
- .env を既に作っているとき、copy-env.sh を実行すると既存のファイルが上書きされてしまう問題があった
- 既に .env があるときはおそらく copy-env.sh の実行はミスの可能性が高いので、上書きはせずに警告を表示するようにした

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](/takahiroanno2024/policy-repository/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
