### PR TITLE
add makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -30,6 +30,7 @@ backend-format:
 
 backend-test:
 	cd packages/backend && npm run test
+
 chat-bot-lint:
 	cd packages/chat-bot && npm run lint
 

--- a/makefile
+++ b/makefile
@@ -1,0 +1,40 @@
+## ショートカット（自分のよく使うものを登録すると便利）
+default: containers-start
+lint: frontend-lint backend-lint chat-bot-lint
+format: frontend-format backend-format chat-bot-format
+test: frontend-test backend-test chat-bot-test
+
+.PHONY: setup
+
+# ターゲット定義（makefile は薄いラッパーとして使う。複雑な処理を書かずシンプルに保つこと）
+containers-start:
+	docker compose watch
+
+setup:
+	sh ./copy-env.sh
+
+frontend-lint:
+	cd packages/frontend && npm run lint
+
+frontend-format:
+	cd packages/frontend && npm run format
+
+frontend-test:
+	cd packages/frontend && npm run test
+
+backend-lint:
+	cd packages/backend && npm run lint
+
+backend-format:
+	cd packages/backend && npm run format
+
+backend-test:
+	cd packages/backend && npm run test
+chat-bot-lint:
+	cd packages/chat-bot && npm run lint
+
+chat-bot-format:
+	cd packages/chat-bot && npm run format
+
+chat-bot-test:
+	cd packages/chat-bot && npm run test

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -7,6 +7,7 @@
     "dev": "ts-node-dev --respawn src/index.ts",
     "build": "tsc && copyfiles -u 2 \"src/config/prompt-templates/*.txt\" dist/config/prompt-templates/",
     "start": "node dist/index.js",
+    "test": "echo 'not implemented yet'",
     "lint": "biome check .",
     "format": "biome check --write ."
   },

--- a/packages/chat-bot/package.json
+++ b/packages/chat-bot/package.json
@@ -7,7 +7,7 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "dev": "ts-node-dev --respawn src/index.ts",
-    "test": "jest",
+    "test": "jest --passWithNoTests",
     "lint": "biome check .",
     "format": "biome check --write ."
   },

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -b && vite build",
     "lint": "biome lint .",
     "format": "biome format --write .",
+    "test": "echo 'not implemented yet'",
     "preview": "vite preview"
   },
   "dependencies": {


### PR DESCRIPTION
# 変更の概要
- makefile を追加した

# 変更の背景
- 初期設定、起動、lint, test などを一発で実行できる makefile を置いた
    - test 未実装の backend, frontend ではその旨表示する echo を書いた
    - chat-bot では test コマンドはあるもののテストケースが一つも実行されずエラーが出ていたので、jest コマンドに --passWithNoTests オプションを付けた
- 対応する readme の更新は https://github.com/digitaldemocracy2030/idobata-analyst/pull/67 でやっている

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](/takahiroanno2024/policy-repository/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
