### PR TITLE
make containers-start の微修正

### DIFF
--- a/makefile
+++ b/makefile
@@ -8,7 +8,7 @@ test: frontend-test backend-test chat-bot-test
 
 # ターゲット定義（makefile は薄いラッパーとして使う。複雑な処理を書かずシンプルに保つこと）
 containers-start:
-	docker compose watch
+	docker compose up --watch
 
 setup:
 	sh ./copy-env.sh


### PR DESCRIPTION
# 変更の概要

- https://github.com/digitaldemocracy2030/idobata-analyst/pull/66 で makefile を追加したが、make containers-start を実行したときに `docker compose watch` を実行するようにしていたが、これだとコンソールにログが出ないので、`docker compose up --watch` を実行するように修正した

# 変更の背景
- ここに変更が必要となった背景を記載してください

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](/takahiroanno2024/policy-repository/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
