### PR TITLE
開発環境で、プロジェクト作成ページにサンプルデータを入れるボタンを置いた

### DIFF
--- a/packages/frontend/src/pages/CsvUploadPage.tsx
+++ b/packages/frontend/src/pages/CsvUploadPage.tsx
@@ -25,6 +25,8 @@ const CsvUploadPage: React.FC = () => {
     () => !!localStorage.getItem("adminKey"),
   );
 
+  const isDevelopment = process.env.NODE_ENV === "development";
+
   // Project form states
   const [projectName, setProjectName] = useState<string>("");
   const [projectDescription, setProjectDescription] = useState<string>("");
@@ -141,6 +143,23 @@ const CsvUploadPage: React.FC = () => {
       setIsProcessing(false);
     }
   };
+
+  const fillSampleData = useCallback(() => {
+    const topics = ["言論", "政治", "経済", "社会", "文化", "環境", "教育"];
+
+    const randomTopic = topics[Math.floor(Math.random() * topics.length)];
+    const timestamp = new Date().toISOString().slice(0, 16).replace("T", " ");
+
+    setProjectName(`${randomTopic}に関する意見収集 (${timestamp})`);
+    setProjectDescription(
+      `${randomTopic}についての一般的な意見を収集・分析するプロジェクトです`,
+    );
+    setExtractionTopic(`${randomTopic}に関する意見や提案`);
+    setContext(
+      `このプロジェクトでは${randomTopic}に関する様々な意見を収集し、賛成・反対の立場や具体的な提案を整理します。
+収集したデータから主要な論点を抽出し、建設的な議論の基盤を作ることを目指しています。`,
+    );
+  }, []);
 
   const processInBatches = useCallback(
     async (data: CsvRow[], batchSize = 100) => {
@@ -300,6 +319,15 @@ const CsvUploadPage: React.FC = () => {
       {/* Project creation form */}
       {currentStep === "project" && (
         <div className="space-y-4">
+          {isDevelopment && (
+            <button
+              type="button"
+              onClick={fillSampleData}
+              className="mb-4 px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700"
+            >
+              サンプルデータを入力（開発環境用）
+            </button>
+          )}
           <div>
             <label className="block text-sm font-medium text-gray-700">
               プロジェクト名


### PR DESCRIPTION
# 変更の概要
- 開発環境で、プロジェクト作成ページにサンプルデータを入れるボタンを置いた

# 変更の背景
- 開発時に動作確認のために適当なデータを毎回入力するのが面倒だった
- ボタンクリックするとサンプルデータが入るようにした
- 
![Screenshot 2025-04-02 at 16 09 11](https://github.com/user-attachments/assets/661369eb-09d2-4a6b-be99-8b6d3f003da5)

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](/takahiroanno2024/policy-repository/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
