### PR TITLE
開発環境でサンプル CSV を読み込めるボタンを置いた

### DIFF
--- a/packages/frontend/public/sample_comments.csv
+++ b/packages/frontend/public/sample_comments.csv
@@ -1,0 +1,301 @@
+content,sourceType,sourceUrl
+SNS時代の言論の自由には新たな課題がある。,,https://chat.app/dvq8fmihxa
+ジェンダー平等の実現に向けた動きが進んでいます。,x,https://x.com/status/63ko42l8sh
+多様な価値観を受け入れることが重要だと思います。,x,https://x.com/status/v2hj3t718t
+教育と福祉の連携が重要です。,x,https://x.com/status/9qe6deqb2y
+多様な価値観を受け入れることが重要です。,form,
+マイクロプラスチック問題が深刻です。,other,
+温暖化対策としての都市緑化が注目されています。,other,
+表現の自由と芸術の関係は繊細です。,youtube,
+多様な声が届く仕組みが必要です。 発言の自由と責任はセットで考えるべきです。,youtube,https://x.com/status/fz08efay7h
+英語教育のあり方が問われています。 進学か就職かの選択肢を広げる必要があります。,youtube,https://youtu.be/h5k4x88dsu
+生活困窮者への支援体制の強化が必要です。,chat,https://form.site/26gspc4spu
+賃上げの動きが経済全体に波及してほしいです。,x,
+環境教育の重要性が増しています。,youtube,
+孤独・孤立の問題が深刻化しています。,chat,
+探究型学習への移行が進行中だと思います。,x,https://chat.app/cqyf3j94zl
+日本のアニメが世界で人気を集めています。,,
+物価高に対応した政策が急がれます。,youtube,
+教育と福祉の連携が重要です。,other,https://x.com/status/a1kzxkhvce
+ベーシックインカムの導入議論が進んでいます。,youtube,
+教員の質の向上が求められています。,x,
+円安が家計に影響を与えています。,,
+地域の祭りが観光資源にもなっています。 文化の多様性を尊重する社会にしたいです。,form,
+孤独・孤立の問題が深刻化しています。,form,https://form.site/4r9f1e57d4
+文化政策への公的支援を増やすべきです。 現代アートへの評価が変わってきています。,other,
+エコなライフスタイルを意識しています。,form,
+キャッシュレス社会の進展が進んでいます。 中間層の減少が社会全体に影響しています。,chat,
+投資教育の普及が望まれます。 賃上げの動きが経済全体に波及してほしいです。,chat,https://youtu.be/ws0k6fh20b
+生物多様性の保全が課題だと思います。,form,
+経済成長と分配のバランスが重要です。 スタートアップ支援が経済を活性化します。,chat,https://youtu.be/85ca8931rh
+温暖化対策としての都市緑化が注目されています。,form,
+SNS時代の言論の自由には新たな課題がある。,chat,https://form.site/8vvlw347iq
+スタートアップ支援が経済を活性化します。 キャッシュレス社会の進展が進んでいます。,chat,
+いじめ対策の強化が進んでいます。,youtube,https://form.site/mglwt4h2w3
+政治とカネの問題が後を絶ちません。,,https://form.site/55gal3n4g9
+探究型学習への移行が進行中だと思います。,,
+表現の自由が尊重される社会を守りたい。,form,
+中間層の減少が社会全体に影響しています。 海外依存度の高い産業構造に不安があります。,form,
+ネット上の誹謗中傷と自由の境界線が曖昧になっています。,chat,https://form.site/7si8057ipc
+都市と地方の格差が広がっています。,youtube,https://x.com/status/1vyv5t690h
+教育現場の働き方改革が必要です。,other,
+ベーシックインカムの導入議論が進んでいます。,form,
+日本のアニメが世界で人気を集めています。,youtube,
+学力格差の是正が課題です。 英語教育のあり方が問われています。,form,https://form.site/shm85m0axm
+日本のアニメが世界で人気を集めています。 外国文化との交流が活発化しています。,other,https://example.com/avsof5tf7l
+物価高に対応した政策が急がれます。 海外依存度の高い産業構造に不安があります。,youtube,
+教員の質の向上が求められています。,x,
+英語教育のあり方が問われています。,other,
+社会保障制度の見直しが必要です。 生活困窮者への支援体制の強化が必要です。,x,
+中間層の減少が社会全体に影響しています。,x,
+環境教育の重要性が増しています。,chat,
+映画や音楽などの文化産業が重要な役割を果たしています。,other,
+多様な価値観を受け入れることが重要です。,x,
+国会審議の透明性を高める工夫が必要です。,form,https://x.com/status/72x0ooh6l2
+地域社会とのつながりが薄れてきています。,other,https://chat.app/piqj7d8yjr
+中間層の減少が社会全体に影響しています。,other,https://example.com/a3s9lnwn6w
+物価高に対応した政策が急がれます。,form,https://x.com/status/t5lpri9zfj
+自然災害の多発が気になります。,youtube,
+表現の自由と芸術の関係は繊細だと思います。,chat,https://x.com/status/yeine7h4ph
+生物多様性の保全が課題です。,,
+政党の公約に具体性がほしいですね。 地方政治の改革も喫緊の課題です。,,https://form.site/d9w9cvbfx5
+再生可能エネルギーの導入が課題です。 企業の環境への取り組みに期待しています。,x,https://example.com/ncd19op05d
+スタートアップ支援が経済を活性化します。,youtube,https://chat.app/8bmg267gbi
+英語教育のあり方が問われています。,form,https://x.com/status/ip14354v0t
+政治とカネの問題が後を絶ちません。,chat,
+多様な声が届く仕組みが必要だと思います。,chat,
+環境教育の重要性が増しています。 企業の環境への取り組みに期待しています。,form,https://x.com/status/69ixiv8n08
+教育現場の働き方改革が必要です。,other,https://example.com/bn3630jze5
+森林保全の必要性が高まっています。,other,
+表現の自由と芸術の関係は繊細です。,other,
+海外依存度の高い産業構造に不安があります。 キャッシュレス社会の進展が進んでいます。,youtube,
+中間層の減少が社会全体に影響しています。 投資教育の普及が望まれます。,youtube,
+現代アートへの評価が変わってきています。,youtube,https://youtu.be/4a9vodth3f
+自由な意見交換が民主主義を支えている。 ネット上の誹謗中傷と自由の境界線が曖昧になっています。,other,
+エコなライフスタイルを意識しています。,youtube,https://youtu.be/5clesw4y2o
+教育と福祉の連携が重要です。,,
+教育現場の働き方改革が必要だと思います。,other,https://x.com/status/f7ovmyrjbz
+生活困窮者への支援体制の強化が必要です。 ジェンダー平等の実現に向けた動きが進んでいます。,youtube,https://x.com/status/pl8wqek8gh
+自由な議論を促す教育も求められています。,chat,https://youtu.be/695dnrzdcw
+キャッシュレス社会の進展が進んでいます。,other,
+多様性を認め合う社会が理想です。,other,https://example.com/xkes9tsegz
+学力格差の是正が課題です。,x,https://example.com/n2styuo1ba
+政党の公約に具体性がほしいですね。,youtube,
+高齢化社会にどう対応するかが問われています。,form,
+企業の環境への取り組みに期待しています。,youtube,
+物価高に対応した政策が急がれます。,chat,
+文化の多様性を尊重する社会にしたいだと思います。,,
+文化政策への公的支援を増やすべきだと思います。,other,
+表現の自由と芸術の関係は繊細だと思います。,other,
+若年層の政治的無関心が課題です。 政治家の説明責任が問われています。,x,https://chat.app/byvih3d58d
+脱炭素社会に向けた取り組みが進んでいます。,chat,https://chat.app/vseclw7yru
+自由な議論を促す教育も求められています。,chat,https://form.site/ebvt7cy8cv
+リーダーシップのある政治家が求められています。 女性議員の比率がもっと増えるべきです。,chat,
+温暖化対策としての都市緑化が注目されています。,form,
+政党の公約に具体性がほしいですね。,,https://x.com/status/p88d71bazg
+投資教育の普及が望まれます。 キャッシュレス社会の進展が進んでいます。,youtube,https://youtu.be/bxhhqgyswf
+言論封殺の動きには注意が必要です。,form,
+エコなライフスタイルを意識しています。,,
+SNS時代の言論の自由には新たな課題がある。 言論封殺の動きには注意が必要です。,other,
+森林保全の必要性が高まっています。,youtube,
+都市と地方の格差が広がっています。,chat,https://form.site/1k2y8jx6j7
+円安が家計に影響を与えています。,other,https://x.com/status/r7on4vxxlt
+進学か就職かの選択肢を広げる必要があります。,x,https://youtu.be/3jc3eheo9u
+地域の祭りが観光資源にもなっています。,x,
+中間層の減少が社会全体に影響しています。 物価高に対応した政策が急がれます。,other,https://x.com/status/immuyjdfd9
+子育て支援制度の充実が求められています。,youtube,
+円安が家計に影響を与えています。,youtube,
+温暖化対策としての都市緑化が注目されています。,chat,https://youtu.be/riej7cw60b
+森林保全の必要性が高まっています。,youtube,https://example.com/iejhem3rd5
+自然災害の多発が気になります。 企業の環境への取り組みに期待しています。,other,
+子育て支援制度の充実が求められています。,chat,https://x.com/status/xijv1946ur
+若年層の政治的無関心が課題だと思います。,other,
+海外との政治的連携が重要になってきています。,other,
+多様性を認め合う社会が理想だと思います。,,
+政治家の説明責任が問われています。,,https://chat.app/kyqyncg4d9
+教育と福祉の連携が重要です。,youtube,
+賃上げの動きが経済全体に波及してほしいです。,other,https://x.com/status/xm1lrjx2x7
+文化の多様性を尊重する社会にしたいだと思います。,chat,
+ジェンダー平等の実現に向けた動きが進んでいます。 社会保障制度の見直しが必要です。,,https://youtu.be/lebzmpcmww
+伝統芸能の保存と継承が課題です。,,https://form.site/gov6uvip13
+ネット上の誹謗中傷と自由の境界線が曖昧になっています。,,https://example.com/brgmc11w5y
+スタートアップ支援が経済を活性化します。,,https://form.site/5ex2ewuv6z
+教員の質の向上が求められています。 探究型学習への移行が進行中です。,chat,https://youtu.be/c4xllkxuub
+ネット上の誹謗中傷と自由の境界線が曖昧になっています。,x,https://chat.app/bfw79hn892
+防災意識の向上が大切です。,other,
+いじめ対策の強化が進んでいます。,,
+温暖化対策としての都市緑化が注目されています。,youtube,https://chat.app/zw6emkjy6l
+現代アートへの評価が変わってきています。,other,https://youtu.be/ttur9g6xls
+再生可能エネルギーの導入が課題だと思います。,,https://form.site/9xjvyo643c
+ベーシックインカムの導入議論が進んでいます。,form,https://form.site/s5m3mlhfza
+発言の自由と責任はセットで考えるべきだと思います。,,
+防災意識の向上が大切です。 ジェンダー平等の実現に向けた動きが進んでいます。,chat,
+女性議員の比率がもっと増えるべきです。,form,https://chat.app/p4bte7duo4
+教員の質の向上が求められています。 子どもの主体性を育てる教育が必要です。,other,https://example.com/aj46gr97s1
+メディアの報道姿勢に対する批判が高まっている。,,https://youtu.be/dwga3qv2hq
+海外依存度の高い産業構造に不安があります。,,https://chat.app/4wnsbzbcf3
+子どもの主体性を育てる教育が必要だと思います。,chat,https://x.com/status/s6y5oa2dj0
+物価高に対応した政策が急がれます。,form,
+自然災害の多発が気になります。,form,https://x.com/status/6pgf2uuzsc
+子どもの主体性を育てる教育が必要です。,chat,
+文化の多様性を尊重する社会にしたいだと思います。,chat,
+賃上げの動きが経済全体に波及してほしいだと思います。,,
+多様な価値観を受け入れることが重要です。 表現の自由が尊重される社会を守りたい。,youtube,
+自由な議論を促す教育も求められています。,other,https://x.com/status/vup5za5zp9
+温暖化対策としての都市緑化が注目されています。,,https://example.com/lvgoa0dess
+メディアの報道姿勢に対する批判が高まっている。,youtube,https://chat.app/lu7ow3n0wg
+言論封殺の動きには注意が必要です。,other,
+自然災害の多発が気になります。,youtube,
+エコなライフスタイルを意識しています。,x,https://chat.app/4au4bnrddq
+ICT教育の推進が進んでいます。 教育と福祉の連携が重要です。,form,https://x.com/status/tg3wzjb4t4
+環境教育の重要性が増しています。,chat,https://x.com/status/w8oyve2daf
+多様性を認め合う社会が理想です。 子育て支援制度の充実が求められています。,form,
+SNS時代の言論の自由には新たな課題がある。 発言の自由と責任はセットで考えるべきです。,chat,https://youtu.be/vibjrsqy6i
+伝統芸能の保存と継承が課題だと思います。,other,https://form.site/n1qjxx67zj
+日本のアニメが世界で人気を集めています。,form,https://youtu.be/p9xxwkqo0c
+都市と地方の格差が広がっています。,,https://x.com/status/osw8sz97b9
+賃上げの動きが経済全体に波及してほしいです。,form,https://example.com/r2it3qffn9
+メディアの報道姿勢に対する批判が高まっている。,,
+子育て支援制度の充実が求められています。,form,
+子どもの主体性を育てる教育が必要です。 探究型学習への移行が進行中です。,other,
+教育と福祉の連携が重要だと思います。,form,https://youtu.be/824g8xlbtl
+キャッシュレス社会の進展が進んでいます。,form,https://form.site/fgg4lna99k
+地域の祭りが観光資源にもなっています。,other,
+企業の環境への取り組みに期待しています。,form,
+再生可能エネルギーの導入が課題だと思います。,chat,
+多様な声が届く仕組みが必要だと思います。,other,https://chat.app/hq8ovuarl4
+子どもの主体性を育てる教育が必要です。 英語教育のあり方が問われています。,form,
+政治とカネの問題が後を絶ちません。,youtube,https://youtu.be/1jnxq2cbuw
+中間層の減少が社会全体に影響しています。,form,https://example.com/ybvfzjk76c
+発言の自由と責任はセットで考えるべきだと思います。,form,https://chat.app/62d6mtjtxs
+探究型学習への移行が進行中だと思います。,youtube,
+文化政策への公的支援を増やすべきです。 文化施設の運営が厳しさを増しています。,other,
+日本のアニメが世界で人気を集めています。,form,
+英語教育のあり方が問われています。 進学か就職かの選択肢を広げる必要があります。,x,https://youtu.be/t8ffhs7yf8
+再生可能エネルギーの導入が課題です。,form,https://x.com/status/tya9tkg7ta
+海外との政治的連携が重要になってきています。,x,
+投資教育の普及が望まれます。,other,
+森林保全の必要性が高まっています。,other,https://youtu.be/hdxe02fvbt
+女性議員の比率がもっと増えるべきです。,,
+リーダーシップのある政治家が求められています。,youtube,https://example.com/tb911lacu4
+リーダーシップのある政治家が求められています。,,https://example.com/1ogqc5u4zf
+映画や音楽などの文化産業が重要な役割を果たしています。 現代アートへの評価が変わってきています。,chat,https://example.com/ht69ju3ozy
+マイクロプラスチック問題が深刻です。,,
+現代アートへの評価が変わってきています。,form,
+リーダーシップのある政治家が求められています。,x,https://chat.app/lonwhn56np
+キャッシュレス社会の進展が進んでいます。,x,https://youtu.be/1uzty1sczc
+文化の多様性を尊重する社会にしたいだと思います。,,https://youtu.be/jwa11y8z39
+森林保全の必要性が高まっています。,x,
+温暖化対策としての都市緑化が注目されています。 脱炭素社会に向けた取り組みが進んでいます。,,https://example.com/0ztb5syfaa
+スタートアップ支援が経済を活性化します。,chat,https://x.com/status/am4plsayz6
+女性議員の比率がもっと増えるべきです。,other,
+教員の質の向上が求められています。,other,
+円安が家計に影響を与えています。,youtube,https://chat.app/221kzjmxiv
+文化政策への公的支援を増やすべきです。 地域の祭りが観光資源にもなっています。,youtube,https://youtu.be/9dbancsu5r
+表現の自由が尊重される社会を守りたい。,other,https://x.com/status/5gaos44mdq
+森林保全の必要性が高まっています。,chat,
+ICT教育の推進が進んでいます。 いじめ対策の強化が進んでいます。,,https://form.site/ngm1jjg006
+政治とカネの問題が後を絶ちません。,,
+現代アートへの評価が変わってきています。,x,https://chat.app/k1g0bk0nxa
+SNS時代の言論の自由には新たな課題がある。 ネット上の誹謗中傷と自由の境界線が曖昧になっています。,other,https://example.com/yy30glxc11
+ベーシックインカムの導入議論が進んでいます。,chat,https://chat.app/cqfm6yg5wn
+自由な議論を促す教育も求められています。,form,
+文化施設の運営が厳しさを増しています。 地域の祭りが観光資源にもなっています。,,https://chat.app/so00btbada
+伝統芸能の保存と継承が課題だと思います。,,https://form.site/oshe6ddjvs
+教員の質の向上が求められています。,form,
+教育と福祉の連携が重要だと思います。,other,https://youtu.be/t1hfp75x2r
+ベーシックインカムの導入議論が進んでいます。 キャッシュレス社会の進展が進んでいます。,chat,
+文化の多様性を尊重する社会にしたいです。 日本のアニメが世界で人気を集めています。,x,https://x.com/status/9bs6xwuk3z
+生活困窮者への支援体制の強化が必要です。 都市と地方の格差が広がっています。,youtube,https://form.site/sc01f7b3jv
+キャッシュレス社会の進展が進んでいます。,,https://form.site/78o38enrv7
+ネット上の誹謗中傷と自由の境界線が曖昧になっています。 多様な声が届く仕組みが必要です。,chat,
+海外との政治的連携が重要になってきています。,chat,
+若年層の政治的無関心が課題だと思います。,youtube,https://example.com/8hm92bmuoz
+円安が家計に影響を与えています。 中間層の減少が社会全体に影響しています。,,
+英語教育のあり方が問われています。,x,https://youtu.be/vrbl4h6rg5
+企業の環境への取り組みに期待しています。,,https://example.com/7nosugnmyl
+外国文化との交流が活発化しています。,,https://example.com/kvq9tljik3
+社会保障制度の見直しが必要だと思います。,form,
+エコなライフスタイルを意識しています。,youtube,https://chat.app/kleckxv2im
+伝統芸能の保存と継承が課題です。,form,
+海外依存度の高い産業構造に不安があります。,x,https://youtu.be/84c9xax0wg
+脱炭素社会に向けた取り組みが進んでいます。 温暖化対策としての都市緑化が注目されています。,chat,
+賃上げの動きが経済全体に波及してほしいです。,,https://example.com/qpyefpclr5
+海外依存度の高い産業構造に不安があります。 中間層の減少が社会全体に影響しています。,youtube,
+マイクロプラスチック問題が深刻です。 環境教育の重要性が増しています。,other,https://youtu.be/3ysidb9pfz
+生活困窮者への支援体制の強化が必要だと思います。,form,https://example.com/s3pa6oo77m
+文化の多様性を尊重する社会にしたいだと思います。,form,
+環境教育の重要性が増しています。 生物多様性の保全が課題です。,,https://form.site/k2371x6n2x
+地域の祭りが観光資源にもなっています。,other,
+政党の公約に具体性がほしいですね。,,
+スタートアップ支援が経済を活性化します。,chat,
+映画や音楽などの文化産業が重要な役割を果たしています。,form,https://youtu.be/gqaq009upd
+賃上げの動きが経済全体に波及してほしいだと思います。,form,
+自由な議論を促す教育も求められています。 ネット上の誹謗中傷と自由の境界線が曖昧になっています。,other,https://form.site/7pn5dv5w9j
+子どもの主体性を育てる教育が必要です。 いじめ対策の強化が進んでいます。,other,https://youtu.be/sbmjwbrqhf
+地域社会とのつながりが薄れてきています。,x,https://form.site/xlqm1s4b84
+ジェンダー平等の実現に向けた動きが進んでいます。,x,https://x.com/status/8rg6mwfsiw
+英語教育のあり方が問われています。 教員の質の向上が求められています。,chat,https://x.com/status/xnx2na2a7a
+経済成長と分配のバランスが重要です。 中間層の減少が社会全体に影響しています。,chat,
+マイクロプラスチック問題が深刻だと思います。,,
+文化の多様性を尊重する社会にしたいです。 現代アートへの評価が変わってきています。,,
+スタートアップ支援が経済を活性化します。,youtube,https://youtu.be/9wja37gv79
+SNS時代の言論の自由には新たな課題がある。,chat,
+多様な声が届く仕組みが必要だと思います。,chat,https://youtu.be/0g334x3lhw
+映画や音楽などの文化産業が重要な役割を果たしています。 文化の多様性を尊重する社会にしたいです。,chat,
+教育と福祉の連携が重要だと思います。,,https://example.com/bblqvyq8bn
+投票率の低下が民主主義を揺るがしています。,youtube,
+自由な議論を促す教育も求められています。 言論封殺の動きには注意が必要です。,chat,
+エコなライフスタイルを意識しています。,youtube,https://chat.app/yqr08olw2f
+物価高に対応した政策が急がれます。,form,https://example.com/ev770dsisu
+中間層の減少が社会全体に影響しています。 投資教育の普及が望まれます。,x,https://form.site/c3qt52heoq
+文化の多様性を尊重する社会にしたいです。 文化政策への公的支援を増やすべきです。,other,https://chat.app/o1gx62m0c7
+教育現場の働き方改革が必要だと思います。,x,
+スタートアップ支援が経済を活性化します。,x,https://youtu.be/13iyrp5q83
+教育と福祉の連携が重要だと思います。,x,
+投票率の低下が民主主義を揺るがしています。,,https://chat.app/xwcq92f3gu
+都市と地方の格差が広がっています。 地域社会とのつながりが薄れてきています。,youtube,
+多様な価値観を受け入れることが重要だと思います。,,
+都市と地方の格差が広がっています。 生活困窮者への支援体制の強化が必要です。,other,https://youtu.be/ovcjgk1s5j
+高齢化社会にどう対応するかが問われています。,youtube,
+海外との政治的連携が重要になってきています。 若年層の政治的無関心が課題です。,,https://chat.app/y527e2x9tl
+教員の質の向上が求められています。,form,
+再生可能エネルギーの導入が課題です。 生物多様性の保全が課題です。,chat,https://x.com/status/aetro6z8no
+いじめ対策の強化が進んでいます。 学力格差の是正が課題です。,,
+賃上げの動きが経済全体に波及してほしいだと思います。,other,https://form.site/cr1t3debfo
+ベーシックインカムの導入議論が進んでいます。,chat,
+若年層の政治的無関心が課題だと思います。,,
+伝統芸能の保存と継承が課題だと思います。,form,https://youtu.be/iynmge2c4f
+表現の自由と芸術の関係は繊細です。 日本のアニメが世界で人気を集めています。,chat,
+生物多様性の保全が課題です。,x,https://youtu.be/s4deyyuii3
+メディアの報道姿勢に対する批判が高まっている。,other,
+ICT教育の推進が進んでいます。 進学か就職かの選択肢を広げる必要があります。,youtube,https://chat.app/vl1hgmd5uf
+地域社会とのつながりが薄れてきています。,x,
+ベーシックインカムの導入議論が進んでいます。,chat,https://example.com/30oyju1hx6
+高齢化社会にどう対応するかが問われています。,form,
+英語教育のあり方が問われています。,other,https://example.com/bda7mohixj
+映画や音楽などの文化産業が重要な役割を果たしています。,form,
+政治家の説明責任が問われています。,chat,
+国会審議の透明性を高める工夫が必要です。,other,https://x.com/status/ddrtc3rltg
+進学か就職かの選択肢を広げる必要があります。,form,
+高齢化社会にどう対応するかが問われています。 生活困窮者への支援体制の強化が必要です。,chat,https://x.com/status/8v2udmv493
+表現の自由と芸術の関係は繊細です。 日本のアニメが世界で人気を集めています。,youtube,https://example.com/iqfrtxop9w
+日本のアニメが世界で人気を集めています。,other,https://x.com/status/f2f4pvqktb
+日本のアニメが世界で人気を集めています。 文化施設の運営が厳しさを増しています。,youtube,
+高齢化社会にどう対応するかが問われています。 社会保障制度の見直しが必要です。,x,https://chat.app/unte4vg3ov
+表現の自由と芸術の関係は繊細です。,youtube,https://youtu.be/bkx1nhsz7f
+国会審議の透明性を高める工夫が必要です。 投票率の低下が民主主義を揺るがしています。,form,https://x.com/status/6gq77jthaf
+発言の自由と責任はセットで考えるべきだと思います。,x,https://youtu.be/njeznxsdts
+生物多様性の保全が課題です。 森林保全の必要性が高まっています。,form,https://x.com/status/g2ga3nfz4w
+ベーシックインカムの導入議論が進んでいます。 海外依存度の高い産業構造に不安があります。,form,
+メディアの報道姿勢に対する批判が高まっている。,other,https://x.com/status/o0airfsorh
+温暖化対策としての都市緑化が注目されています。,chat,
+教育現場の働き方改革が必要です。 ICT教育の推進が進んでいます。,x,
+政治とカネの問題が後を絶ちません。,other,
+日本のアニメが世界で人気を集めています。 現代アートへの評価が変わってきています。,chat,https://x.com/status/340zqox4j4
+スタートアップ支援が経済を活性化します。 投資教育の普及が望まれます。,youtube,
+キャッシュレス社会の進展が進んでいます。 投資教育の普及が望まれます。,chat,
+進学か就職かの選択肢を広げる必要があります。 ICT教育の推進が進んでいます。,chat,
+温暖化対策としての都市緑化が注目されています。,youtube,https://youtu.be/7410uwunme
+女性議員の比率がもっと増えるべきだと思います。,,https://chat.app/mhz2mudzvn
+賃上げの動きが経済全体に波及してほしいだと思います。,other,https://example.com/bir4rxk6go

--- a/packages/frontend/src/pages/CsvUploadPage.tsx
+++ b/packages/frontend/src/pages/CsvUploadPage.tsx
@@ -161,6 +161,40 @@ const CsvUploadPage: React.FC = () => {
     );
   }, []);
 
+  const loadSampleCsv = useCallback(async () => {
+    if (currentStep !== "upload") return;
+
+    try {
+      setStatus("サンプルCSVを読み込み中...");
+
+      const sampleCsvPath = "/sample_comments.csv";
+
+      const response = await fetch(sampleCsvPath);
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const csvText = await response.text();
+      const csvBlob = new Blob([csvText], { type: "text/csv" });
+      const file = new File([csvBlob], "sample_comments.csv", {
+        type: "text/csv",
+      });
+
+      const syntheticEvent = {
+        target: {
+          files: [file],
+        },
+      } as unknown as React.ChangeEvent<HTMLInputElement>;
+
+      handleFileSelect(syntheticEvent);
+    } catch (error) {
+      console.error("Error loading sample CSV:", error);
+      setStatus(
+        `サンプルCSVの読み込みに失敗しました: ${error instanceof Error ? error.message : "不明なエラー"}`,
+      );
+    }
+  }, [currentStep, handleFileSelect]);
+
   const processInBatches = useCallback(
     async (data: CsvRow[], batchSize = 100) => {
       const totalBatches = Math.ceil(data.length / batchSize);
@@ -392,6 +426,16 @@ const CsvUploadPage: React.FC = () => {
       {/* CSV upload form */}
       {currentStep === "upload" && (
         <div className="space-y-4">
+          {isDevelopment && (
+            <button
+              type="button"
+              onClick={loadSampleCsv}
+              className="mb-4 px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700"
+              disabled={isProcessing}
+            >
+              サンプルデータを読み込む（開発環境用）
+            </button>
+          )}
           <div>
             <label className="block text-sm font-medium text-gray-700">
               CSVファイル

--- a/packages/frontend/src/pages/CsvUploadPage.tsx
+++ b/packages/frontend/src/pages/CsvUploadPage.tsx
@@ -25,6 +25,8 @@ const CsvUploadPage: React.FC = () => {
     () => !!localStorage.getItem("adminKey"),
   );
 
+  const isDevelopment = process.env.NODE_ENV === "development";
+
   // Project form states
   const [projectName, setProjectName] = useState<string>("");
   const [projectDescription, setProjectDescription] = useState<string>("");
@@ -141,6 +143,23 @@ const CsvUploadPage: React.FC = () => {
       setIsProcessing(false);
     }
   };
+
+  const fillSampleData = useCallback(() => {
+    const topics = ["言論", "政治", "経済", "社会", "文化", "環境", "教育"];
+
+    const randomTopic = topics[Math.floor(Math.random() * topics.length)];
+    const timestamp = new Date().toISOString().slice(0, 16).replace("T", " ");
+
+    setProjectName(`${randomTopic}に関する意見収集 (${timestamp})`);
+    setProjectDescription(
+      `${randomTopic}についての一般的な意見を収集・分析するプロジェクトです`,
+    );
+    setExtractionTopic(`${randomTopic}に関する意見や提案`);
+    setContext(
+      `このプロジェクトでは${randomTopic}に関する様々な意見を収集し、賛成・反対の立場や具体的な提案を整理します。
+収集したデータから主要な論点を抽出し、建設的な議論の基盤を作ることを目指しています。`,
+    );
+  }, []);
 
   const processInBatches = useCallback(
     async (data: CsvRow[], batchSize = 100) => {
@@ -300,6 +319,15 @@ const CsvUploadPage: React.FC = () => {
       {/* Project creation form */}
       {currentStep === "project" && (
         <div className="space-y-4">
+          {isDevelopment && (
+            <button
+              type="button"
+              onClick={fillSampleData}
+              className="mb-4 px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700"
+            >
+              サンプルデータを入力（開発環境用）
+            </button>
+          )}
           <div>
             <label className="block text-sm font-medium text-gray-700">
               プロジェクト名


### PR DESCRIPTION
# 変更の概要
- 開発環境でプロジェクト作成時に、サンプル CSV を読み込めるボタンを置いた
- サンプル CSV ファイルを作成して置いた
    - Slack で動作確認用に置いてあったダミーデータをレポジトリに置いていいかどうか少し迷ったので、ChatGPT にダミーデータを作らせた https://chatgpt.com/share/67ececb7-a83c-8006-9b6e-e9daf3a22722
    - https://github.com/digitaldemocracy2030/idobata-analyst/pull/93 で出てくるテーマと関連するテーマのコメントを生成している

![Screenshot 2025-04-02 at 17 09 49](https://github.com/user-attachments/assets/839b05bd-1dd2-4861-b53d-7f6449d875af)

件数表示が変だけどこれは既存のバグっぽいので https://github.com/digitaldemocracy2030/idobata-analyst/pull/95 で修正

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](/takahiroanno2024/policy-repository/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
