### PR TITLE
CSV プレビューの小さなバグ修正

### DIFF
--- a/packages/frontend/src/pages/CsvUploadPage.tsx
+++ b/packages/frontend/src/pages/CsvUploadPage.tsx
@@ -85,17 +85,24 @@ const CsvUploadPage: React.FC = () => {
 
       Papa.parse<CsvRow>(file, {
         header: true,
-        preview: 1,
         complete: (results: ParseResult<CsvRow>) => {
           const hasRequiredColumns =
             results.meta.fields?.includes("content") ?? false;
+
+          // Filter out empty rows (where all fields are empty)
+          const filteredData = results.data.filter((row) =>
+            Object.values(row).some(
+              (value) => value !== null && value !== undefined && value !== "",
+            ),
+          );
+
           setPreviewData({
-            totalRows: results.data.length,
+            totalRows: filteredData.length,
             isValid: hasRequiredColumns,
           });
           setStatus(
             hasRequiredColumns
-              ? `${file.name} が選択されました (${results.data.length}件のデータ)`
+              ? `${file.name} が選択されました (${filteredData.length}件のデータ)`
               : "CSVファイルに必要な列(content)が含まれていません",
           );
         },


### PR DESCRIPTION
# 変更の概要
CSV のプレビュー時に出るデータ件数表示が変だったので修正した
- 常に1件と表示されてしまっていた
    - preview: 1 が付いていて、1行しかデータを読み出していないにも関わらず、データの件数を表示していたので変になっていた
    - CSVのパースには100万行〜規模のデータでもなければ今どきの PC では大した時間はかからないはずなので、preview: 1 を外してしまうことにした
- CSV を読み込む際に、末尾の空行が含まれてデータの件数が1件ずれてしまうことがあった（CSV ファイルの作り方によって、末尾に空行が入ることと入らないことがあり、末尾に空行が入る時のみ問題が発生する）
    - 空行はフィルタリングするようにして、実際のデータ数と表示数がずれないようにした

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](/takahiroanno2024/policy-repository/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
