### PR TITLE
コメントの左側のバーの色を、各立場（スタンス）に対応する円グラフの色と一致させた

### DIFF
--- a/packages/frontend/src/components/StanceGraphComponent.tsx
+++ b/packages/frontend/src/components/StanceGraphComponent.tsx
@@ -21,7 +21,7 @@ interface StanceStats {
 }
 
 // 円グラフ用の色
-const CHART_COLORS = [
+export const CHART_COLORS = [
   "#3B82F6", // blue-500
   "#10B981", // emerald-500
   "#F59E0B", // amber-500
@@ -31,6 +31,7 @@ const CHART_COLORS = [
   "#6366F1", // indigo-500
   "#14B8A6", // teal-500
 ];
+export const OTHER_COLOR = "#6B7280"; // gray-500
 
 // カスタムツールチップ
 const CustomTooltip = ({ active, payload }: any) => {
@@ -97,6 +98,7 @@ export const StanceGraphComponent = ({
     .map(([stanceId, stats]) => ({
       name: getStanceName(stanceId),
       value: stats.count,
+      isOther: stanceId === "other",
     }));
 
   return (
@@ -126,7 +128,11 @@ export const StanceGraphComponent = ({
                 {chartData.map((_, index) => (
                   <Cell
                     key={`cell-${chartData[index].name}-${index}`}
-                    fill={CHART_COLORS[index % CHART_COLORS.length]}
+                    fill={
+                      chartData[index].isOther
+                        ? OTHER_COLOR
+                        : CHART_COLORS[index % CHART_COLORS.length]
+                    }
                   />
                 ))}
               </Pie>

--- a/packages/frontend/src/components/StanceReport.tsx
+++ b/packages/frontend/src/components/StanceReport.tsx
@@ -172,11 +172,11 @@ export const StanceReport = ({
 
   //コメント種類分布用計算
   // コメントの種類ごとの件数を集計
-  const sourceTypeCounts: { [key: CommentSourceType]: number } = {};
-  comments.forEach(comment => {
-    const sourceType = comment.sourceType || 'other';
+  const sourceTypeCounts: Record<string, number> = {};
+  for (const comment of comments) {
+    const sourceType = comment.sourceType || "other";
     sourceTypeCounts[sourceType] = (sourceTypeCounts[sourceType] || 0) + 1;
-  });
+  }
   // 全体のコメント数
   const totalComments = comments.length;
 
@@ -226,20 +226,28 @@ export const StanceReport = ({
 
         {/*コメント種類分布*/}
         <div className="text-right mb-4">
-        コメントの種類分布：
-        {Object.entries(sourceTypeCounts)
-          .sort(([, countA], [, countB]) => countB - countA)
-          .map(([sourceType, count], index) => {
-            const percentage = totalComments > 0 ? ((count / totalComments) * 100).toFixed(1) : '0.0';
-            const sourceTypeName = getSourceTypeName(sourceType as CommentSourceType);
-            const style = getSourceTypeStyle(sourceType as CommentSourceType);
-            return (
-              <span key={sourceType} className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium mr-1 ${style}`}>
-                {sourceTypeName}:{count}件({percentage}%)
-              </span>
-            );
-          })}
-      </div>
+          コメントの種類分布：
+          {Object.entries(sourceTypeCounts)
+            .sort(([, countA], [, countB]) => countB - countA)
+            .map(([sourceType, count]) => {
+              const percentage =
+                totalComments > 0
+                  ? ((count / totalComments) * 100).toFixed(1)
+                  : "0.0";
+              const sourceTypeName = getSourceTypeName(
+                sourceType as CommentSourceType,
+              );
+              const style = getSourceTypeStyle(sourceType as CommentSourceType);
+              return (
+                <span
+                  key={sourceType}
+                  className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium mr-1 ${style}`}
+                >
+                  {sourceTypeName}:{count}件({percentage}%)
+                </span>
+              );
+            })}
+        </div>
 
         {/* コメントリスト */}
         <div className="space-y-3 my-4">

--- a/packages/frontend/src/components/StanceReport.tsx
+++ b/packages/frontend/src/components/StanceReport.tsx
@@ -6,7 +6,11 @@ import { analyzeStances } from "../config/api";
 import type { Comment, CommentSourceType } from "../types/comment";
 import type { Project, Question, StanceAnalysisReport } from "../types/project";
 import { convertBoldBrackets } from "../utils/markdownHelper";
-import { StanceGraphComponent } from "./StanceGraphComponent";
+import {
+  CHART_COLORS,
+  OTHER_COLOR,
+  StanceGraphComponent,
+} from "./StanceGraphComponent";
 
 interface StanceAnalyticsProps {
   comments: Comment[];
@@ -263,13 +267,23 @@ export const StanceReport = ({
                             <div
                               key={comment._id}
                               className={`
-                              bg-white px-3 py-2 text-sm border-l-4 border-blue-400
+                              bg-white px-3 py-2 text-sm border-l-4
                               ${
                                 !expandedStances[stanceId] && index === 2
                                   ? "relative"
                                   : ""
                               }
                             `}
+                              style={{
+                                borderLeftColor:
+                                  stanceId === "other"
+                                    ? OTHER_COLOR
+                                    : CHART_COLORS[
+                                        selectedQuestion.stances.findIndex(
+                                          (s) => s.id === stanceId,
+                                        ) % CHART_COLORS.length
+                                      ],
+                              }}
                             >
                               <div className="flex items-center justify-between">
                                 <div className="flex-1">


### PR DESCRIPTION
# 変更の概要
- https://github.com/digitaldemocracy2030/idobata-analyst/issues/15 を実装した
- 円グラフ上の色と、コメントに添える色を一致させるようにした
- 「その他」用の色を導入し、「その他」は常にその色になるようにした

![Screenshot 2025-04-05 at 0 59 54](https://github.com/user-attachments/assets/2bfd9cfa-4db2-4124-ac15-02fc528cae8e)

# 変更の背景

- https://github.com/digitaldemocracy2030/idobata-analyst/pull/37 で同 issue に PR を立てていただいていたが、https://github.com/digitaldemocracy2030/idobata-analyst/pull/37#issuecomment-2743121886 が解消されておらず、まだマージできなさそうな状態であった
- 先週の定例の際に状況確認したい旨話が出たので https://github.com/digitaldemocracy2030/idobata-analyst/issues/15#issuecomment-2763375494 や https://w1740803485-clv347541.slack.com/archives/C08FF5MM59C/p1743256551200759 でメンションしてみたものの、お忙しいのか返信いただけていないので、こちらの PR で改めて実装することにした

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](/takahiroanno2024/policy-repository/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
