### PR TITLE
implement cacheService and use it in openRouterService

### DIFF
--- a/packages/backend/src/services/cacheService.ts
+++ b/packages/backend/src/services/cacheService.ts
@@ -1,0 +1,93 @@
+import mongoose, { type Document, Schema } from "mongoose";
+
+interface ICache extends Document {
+  key: string;
+  value: any;
+  expiresAt?: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const defaultExpirationInSeconds = 60 * 60 * 24 * 7; // 7 days
+
+const CacheSchema = new Schema<ICache>(
+  {
+    key: { type: String, required: true, unique: true, index: true },
+    value: { type: Schema.Types.Mixed, required: true },
+    expiresAt: { type: Date, default: null, index: true },
+  },
+  { timestamps: true },
+);
+
+CacheSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
+const CacheModel = mongoose.model<ICache>("Cache", CacheSchema);
+
+export class CacheService {
+  /**
+   * Write data to cache
+   * @param key - Unique key for the cached data
+   * @param value - Data to cache
+   * @param expirationInSeconds - Time to live in seconds (optional)
+   * @returns Promise resolving to the cached document
+   */
+  async write(
+    key: string,
+    value: any,
+    expirationInSeconds?: number,
+  ): Promise<ICache> {
+    const expiresAt = expirationInSeconds
+      ? new Date(Date.now() + expirationInSeconds * 1000)
+      : new Date(Date.now() + defaultExpirationInSeconds * 1000);
+
+    const update = {
+      value,
+      ...(expiresAt && { expiresAt }),
+    };
+
+    return CacheModel.findOneAndUpdate({ key }, update, {
+      upsert: true,
+      new: true,
+    });
+  }
+
+  /**
+   * Read data from cache
+   * @param key - Key of the cached data
+   * @returns Promise resolving to the cached value or null if not found or expired
+   */
+  async read<T = any>(key: string): Promise<T | null> {
+    const cacheItem = await CacheModel.findOne({
+      key,
+      $or: [{ expiresAt: { $gt: new Date() } }, { expiresAt: null }],
+    });
+
+    return cacheItem ? (cacheItem.value as T) : null;
+  }
+
+  /**
+   * Fetch data from cache or generate and cache if not found
+   * @param key - Key for the cached data
+   * @param generator - Function to generate data if not in cache
+   * @param expirationInSeconds - Time to live in seconds (optional)
+   * @returns Promise resolving to the data
+   */
+  async fetch<T = any>(
+    key: string,
+    generator: () => Promise<T>,
+    expirationInSeconds?: number,
+  ): Promise<T> {
+    const cachedValue = await this.read<T>(key);
+
+    if (cachedValue !== null) {
+      return cachedValue;
+    }
+
+    const generatedValue = await generator();
+    await this.write(key, generatedValue, expirationInSeconds);
+
+    return generatedValue;
+  }
+}
+
+export default new CacheService();

--- a/packages/backend/src/services/openRouterService.ts
+++ b/packages/backend/src/services/openRouterService.ts
@@ -1,5 +1,7 @@
+import crypto from "crypto";
 import OpenAI from "openai";
 import type { ChatCompletionCreateParams } from "openai/resources/chat/completions";
+import cacheService from "./cacheService";
 
 const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY;
 if (!OPENROUTER_API_KEY) {
@@ -25,7 +27,33 @@ class OpenRouterService {
 
     for (let num_trials = 1; num_trials <= max_retries; num_trials++) {
       try {
-        return await this.chat_internal(options);
+        const canonicalOptionJSON = JSON.stringify(
+          options,
+          (key, value) => {
+            if (value && typeof value === "object" && !Array.isArray(value)) {
+              return Object.keys(value)
+                .sort()
+                .reduce<Record<string, any>>((sorted, key) => {
+                  sorted[key] = value[key];
+                  return sorted;
+                }, {});
+            }
+            return value;
+          },
+          2,
+        );
+        const cacheKey = crypto
+          .createHash("sha1")
+          .update(canonicalOptionJSON)
+          .digest("hex");
+
+        return await cacheService.fetch(
+          cacheKey,
+          () => this.chat_internal(options),
+          process.env.NODE_ENV === "development"
+            ? 60 * 60 * 24 * 180 // 開発環境では節約のためにレスポンスを180日間キャッシュ
+            : 60 * 60 * 24 * 1, // 本番環境では保守的に1日程度キャッシュ
+        );
       } catch (error: any) {
         console.log(`Error in trial ${num_trials}/${max_retries}:`, error);
 


### PR DESCRIPTION
# 変更の概要
- https://github.com/digitaldemocracy2030/idobata-analyst/issues/63 を実装した
- cacheService を追加した。KVS 的なインターフェース read, write, fetch を実装し、Mongo DB をキャッシュサーバーとして使えるようにした
- openRouterService のリクエストパラメータの digest をキーにして、レスポンスをキャッシュするようにした

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](/takahiroanno2024/policy-repository/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [ ] CLAの内容を読み、同意しました
