### PR TITLE
ディスプレイの大きさに合わせてページ幅を広げるようにした

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -17,7 +17,7 @@ function App() {
       <div className={`min-h-screen ${!isEmbedded ? "bg-gray-50" : ""}`}>
         {isAdmin && !isEmbedded && (
           <nav className="bg-white shadow-sm">
-            <div className="max-w-4xl mx-auto px-4 py-3 flex gap-4">
+            <div className="mx-auto px-4 py-3 flex gap-4 max-w-[90%] w-full">
               <Link to="/" className="text-blue-500 hover:text-blue-600">
                 ホーム
               </Link>

--- a/packages/frontend/src/components/PromptSettingsForm.tsx
+++ b/packages/frontend/src/components/PromptSettingsForm.tsx
@@ -91,7 +91,7 @@ export const PromptSettingsForm: React.FC<PromptSettingsFormProps> = ({
   };
 
   return (
-    <div className="max-w-4xl mx-auto p-4">
+    <div className="max-w-[90%] w-full mx-auto p-4">
       <h2 className="text-2xl font-bold mb-4">プロンプト設定</h2>
 
       {/* プロンプトタイプ選択 */}

--- a/packages/frontend/src/pages/HomePage.tsx
+++ b/packages/frontend/src/pages/HomePage.tsx
@@ -4,7 +4,7 @@ export const HomePage = () => {
   const isAdmin = !!localStorage.getItem("adminKey");
 
   return (
-    <div className="max-w-4xl mx-auto py-8 px-4">
+    <div className="max-w-[90%] w-full mx-auto py-8 px-4">
       <div className="text-center">
         <h1 className="text-4xl font-bold text-gray-900 mb-4">
           コメント分析システム

--- a/packages/frontend/src/pages/ProjectListPage.tsx
+++ b/packages/frontend/src/pages/ProjectListPage.tsx
@@ -128,7 +128,7 @@ export const ProjectListPage = () => {
   }
 
   return (
-    <div className="max-w-4xl mx-auto py-8 px-4">
+    <div className="max-w-[90%] w-full mx-auto py-8 px-4">
       <div className="flex justify-between items-center mb-8">
         <h1 className="text-3xl font-bold text-gray-900">プロジェクト一覧</h1>
         <button

--- a/packages/frontend/src/pages/ProjectPage.tsx
+++ b/packages/frontend/src/pages/ProjectPage.tsx
@@ -126,7 +126,7 @@ export const ProjectPage = () => {
 
   if (isLoading) {
     return (
-      <div className="max-w-4xl mx-auto py-8 px-4">
+      <div className="max-w-[90%] w-full mx-auto py-8 px-4">
         <div className="text-center">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500 mx-auto" />
           <p className="mt-4 text-gray-500">読み込み中...</p>
@@ -137,7 +137,7 @@ export const ProjectPage = () => {
 
   if (!projectId || !project) {
     return (
-      <div className="max-w-4xl mx-auto py-8 px-4">
+      <div className="max-w-[90%] w-full mx-auto py-8 px-4">
         <div className="text-center">
           <p className="text-red-500">プロジェクトが見つかりませんでした</p>
         </div>
@@ -146,7 +146,7 @@ export const ProjectPage = () => {
   }
 
   return (
-    <div className="max-w-4xl mx-auto py-8 px-4">
+    <div className="max-w-[90%] w-full mx-auto py-8 px-4">
       <h1 className="text-3xl font-bold text-gray-900 mb-2">{project.name}</h1>
       {project.description && (
         <p className="text-gray-700 mb-8">{project.description}</p>

--- a/packages/frontend/src/pages/PromptSettingsPage.tsx
+++ b/packages/frontend/src/pages/PromptSettingsPage.tsx
@@ -10,7 +10,7 @@ export const PromptSettingsPage: React.FC = () => {
 
   return (
     <div className="container mx-auto py-8">
-      <div className="max-w-4xl mx-auto">
+      <div className="max-w-[90%] w-full mx-auto">
         <h1 className="text-3xl font-bold mb-8">プロンプト設定</h1>
         <div className="bg-white shadow-md rounded-lg p-6">
           <p className="text-gray-600 mb-6">


### PR DESCRIPTION
# 変更の概要
- 最大コンテンツ幅 4xl で固定されていたが、ディスプレイが大きいときに余白が無駄に広くなってしまうため、ディスプレイ幅の90%を最大コンテンツ幅に定義し直した

before

![Screenshot 2025-04-06 at 4 01 30](https://github.com/user-attachments/assets/b25c33b1-b443-48f8-ba1c-673d94ebcaa3)

after

![Screenshot 2025-04-06 at 4 00 43](https://github.com/user-attachments/assets/a6ca6a32-2843-421c-a021-c1e7cbf7aab6)

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](/takahiroanno2024/policy-repository/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました
